### PR TITLE
feat: add classifier language flag and settings pane

### DIFF
--- a/internal/classifier/classifier.core.yml
+++ b/internal/classifier/classifier.core.yml
@@ -106,6 +106,7 @@ workflows:
           or:
             - "result.contentType in flags.delete_content_types"
             - "flags.delete_xxx && result.contentType == contentType.xxx"
+            - "flags.delete_non_english && result.languages.size() > 0 && !result.languages.exists(l, l == 'en')"
         if_action: delete
 extensions:
   audio:
@@ -271,9 +272,11 @@ flag_definitions:
   tmdb_enabled: bool
   delete_content_types: content_type_list
   delete_xxx: bool
+  delete_non_english: bool
 flags:
   local_search_enabled: true
   apis_enabled: true
   tmdb_enabled: true
   delete_content_types: []
   delete_xxx: false
+  delete_non_english: false

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -195,6 +195,23 @@ func TestClassifier(t *testing.T) {
 				},
 			},
 		},
+		{
+			torrent: model.Torrent{
+				Name:        "Le Film (2000) FRENCH 720p.mkv",
+				FilesStatus: model.FilesStatusSingle,
+				Extension:   model.NewNullString("mkv"),
+				Size:        1000000000,
+			},
+			flags: Flags{
+				"delete_non_english":   true,
+				"local_search_enabled": false,
+				"apis_enabled":         false,
+			},
+			expectedErr: classification.RuntimeError{
+				Path:  []string{"workflows", "default", "[6]", "if_else", "if_action", "delete"},
+				Cause: classification.ErrDeleteTorrent,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("torrent: %s", tc.torrent.Name), func(t *testing.T) {

--- a/internal/classifier/config.go
+++ b/internal/classifier/config.go
@@ -1,17 +1,19 @@
 package classifier
 
 type Config struct {
-	Workflow    string
-	Keywords    map[string][]string
-	Extensions  map[string][]string
-	Flags       map[string]any
-	DeleteXxx   bool
-	Concurrency int
+	Workflow         string
+	Keywords         map[string][]string
+	Extensions       map[string][]string
+	Flags            map[string]any
+	DeleteXxx        bool
+	DeleteNonEnglish bool
+	Concurrency      int
 }
 
 func NewDefaultConfig() Config {
 	return Config{
-		Workflow:    "default",
-		Concurrency: 10,
+		Workflow:         "default",
+		Concurrency:      10,
+		DeleteNonEnglish: false,
 	}
 }

--- a/internal/classifier/source_provider.go
+++ b/internal/classifier/source_provider.go
@@ -131,6 +131,10 @@ func (c configSourceProvider) source() (Source, error) {
 		fs["delete_xxx"] = true
 	}
 
+	if c.config.DeleteNonEnglish {
+		fs["delete_non_english"] = true
+	}
+
 	if !c.tmdbEnabled {
 		fs["tmdb_enabled"] = false
 	}

--- a/webui/src/app/app.routes.ts
+++ b/webui/src/app/app.routes.ts
@@ -86,6 +86,13 @@ export const routes: Routes = [
     ],
   },
   {
+    path: "settings",
+    loadComponent: () =>
+      import("./settings/settings.component").then(
+        (c) => c.SettingsComponent,
+      ),
+  },
+  {
     path: "**",
     loadComponent: () =>
       import("./not-found/not-found.component").then(

--- a/webui/src/app/settings/settings.component.html
+++ b/webui/src/app/settings/settings.component.html
@@ -1,0 +1,8 @@
+<h1>Settings</h1>
+<label>
+  <input type="checkbox" [formControl]="deleteNonEnglish" />
+  Delete non-English torrents
+</label>
+<div>
+  <button mat-raised-button color="primary" (click)="save()">Save</button>
+</div>

--- a/webui/src/app/settings/settings.component.spec.ts
+++ b/webui/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { SettingsComponent } from "./settings.component";
+
+describe("SettingsComponent", () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SettingsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webui/src/app/settings/settings.component.ts
+++ b/webui/src/app/settings/settings.component.ts
@@ -1,0 +1,22 @@
+import { Component } from "@angular/core";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { AppModule } from "../app.module";
+
+@Component({
+  selector: "app-settings",
+  standalone: true,
+  templateUrl: "./settings.component.html",
+  imports: [AppModule, ReactiveFormsModule],
+})
+export class SettingsComponent {
+  deleteNonEnglish = new FormControl(false);
+
+  save(): void {
+    const value = this.deleteNonEnglish.value ? "1" : "0";
+    try {
+      localStorage.setItem("delete_non_english", value);
+    } catch {
+      // ignore storage failures
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `DeleteNonEnglish` flag to classifier config and workflow
- provide settings pane in web UI with toggle for deleting non-English torrents
- include test for language-based deletion

## Testing
- `go test ./...`
- `CHROME_BIN=/usr/bin/chromium-browser npm test` *(fails: Chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_689bcefb1c208327b05b19bc1a1ce0b8